### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/src/main/go/infra/error.go
+++ b/src/main/go/infra/error.go
@@ -59,7 +59,7 @@ func HandleAPIError(context *gin.Context, message string, cause error) bool {
 	var handle = cause != nil
 	if handle {
 		glog.Error(message, ": ", cause)
-		context.IndentedJSON(http.StatusInternalServerError, gin.H{"error": message})
+		context.JSON(http.StatusInternalServerError, gin.H{"error": message})
 	}
 	return handle
 }

--- a/src/main/go/infra/gin_server.go
+++ b/src/main/go/infra/gin_server.go
@@ -55,12 +55,15 @@ func (server *GinServer) configRootHMTLAndDependenciesRoute() {
 	glog.Infof("Serving .js, .js.map, .css files from root to load bundles")
 	server.router.GET(
 		"/:filepath", func(context *gin.Context) {
+
 			file := context.Param("filepath")
+
 			// Validate the file parameter to prevent path traversal
 			if strings.Contains(file, "/") || strings.Contains(file, "\\") || strings.Contains(file, "..") {
 				context.String(http.StatusBadRequest, "Invalid file name")
 				return
 			}
+
 			if strings.HasSuffix(file, ".js") ||
 				strings.HasSuffix(file, ".js.map") ||
 				strings.HasSuffix(file, ".css") ||
@@ -82,7 +85,7 @@ func (server *GinServer) configUnknownStandardRoutes() {
 			if context.Request.Method == "GET" && !server.isRequestToAPI(context) {
 				server.handleGetAsToRoot(context)
 			} else {
-				context.String(404, "Not Found")
+				context.String(http.StatusNotFound, "Not Found")
 			}
 		},
 	)

--- a/src/main/go/infra/gin_server.go
+++ b/src/main/go/infra/gin_server.go
@@ -56,6 +56,11 @@ func (server *GinServer) configRootHMTLAndDependenciesRoute() {
 	server.router.GET(
 		"/:filepath", func(context *gin.Context) {
 			file := context.Param("filepath")
+			// Validate the file parameter to prevent path traversal
+			if strings.Contains(file, "/") || strings.Contains(file, "\\") || strings.Contains(file, "..") {
+				context.String(http.StatusBadRequest, "Invalid file name")
+				return
+			}
 			if strings.HasSuffix(file, ".js") ||
 				strings.HasSuffix(file, ".js.map") ||
 				strings.HasSuffix(file, ".css") ||


### PR DESCRIPTION
Potential fix for [https://github.com/benizzio/open-asset-allocator/security/code-scanning/1](https://github.com/benizzio/open-asset-allocator/security/code-scanning/1)

To fix the problem, we need to validate the user input to ensure it does not contain any path traversal sequences or invalid characters. We can achieve this by checking that the input does not contain any path separators ("/" or "\\") or ".." sequences. This ensures that the input is a single file name and not a path that could traverse directories.

1. Add a validation check for the `file` variable to ensure it does not contain any path separators or ".." sequences.
2. If the validation fails, return an error response to the user.
3. If the validation passes, proceed with the existing logic to serve the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
