### PR TITLE
Fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 on:
   pull_request:
 


### PR DESCRIPTION
Potential fix for [https://github.com/benizzio/open-asset-allocator/security/code-scanning/2](https://github.com/benizzio/open-asset-allocator/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimum required permissions for the workflow. Since the workflow only checks out code and runs tests, it does not require any write permissions. The `contents: read` permission is sufficient for these operations. This change will ensure that the workflow explicitly limits the permissions of the `GITHUB_TOKEN` to the least privilege necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
