### PR TITLE
Manage portfolio allocation total market value bugfix

### DIFF
--- a/src/main/web-static/websrc/components/portfolio-history-management.ts
+++ b/src/main/web-static/websrc/components/portfolio-history-management.ts
@@ -155,6 +155,7 @@ const portfolioHistoryManagement = {
         focusOnNewLine(newRow);
         // Process the newly added row with htmx to enable bindings
         htmx.process(newRow);
+        htmx.trigger(newRow, "htmx:afterSettle");
     },
 
     assetActionButtonClickHandler(formRowIndex: number, formUniqueId: string) {


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `portfolioHistoryManagement` component. After dynamically adding and processing a new row with htmx, it now explicitly triggers the `htmx:afterSettle` event to ensure any listeners or additional behaviors tied to this event are executed.

- Enhancement to dynamic row handling:
  * After calling `htmx.process(newRow)`, the code now triggers the `htmx:afterSettle` event on the newly added row to support any post-processing logic that depends on this event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event handling for newly added portfolio history rows to ensure proper behavior on row insertion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->