### PR TITLE
Harden DuckDB CLI image on Ubuntu 24.04 LTS

### DIFF
--- a/src/main/docker/duckdb/Dockerfile
+++ b/src/main/docker/duckdb/Dockerfile
@@ -5,9 +5,21 @@ FROM ubuntu:24.04
 WORKDIR /duckdb
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends unzip ca-certificates \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates=20260601~24.04.1 \
+        unzip=6.0-28ubuntu4.1 \
+        wget=1.21.4-1ubuntu4.4 \
     && rm -rf /var/lib/apt/lists/*
-ADD https://github.com/duckdb/duckdb/releases/download/v1.2.2/duckdb_cli-linux-amd64.zip /duckdb/duckdb.zip
-RUN unzip duckdb.zip && rm duckdb.zip
+RUN wget --quiet --https-only --output-document=duckdb.zip \
+        https://github.com/duckdb/duckdb/releases/download/v1.2.2/duckdb_cli-linux-amd64.zip \
+    && printf '%s\n' "fc153822f59283e0a9374168cce5bc85a9985e699d9857842597882062fd2cb5  duckdb.zip" \
+        > duckdb.zip.sha256 \
+    && sha256sum -c duckdb.zip.sha256 \
+    && unzip duckdb.zip \
+    && rm duckdb.zip duckdb.zip.sha256 \
+    && groupadd --gid 10001 duckdb \
+    && useradd --uid 10001 --gid duckdb --home-dir /duckdb --no-create-home --shell /usr/sbin/nologin duckdb \
+    && chown -R duckdb:duckdb /duckdb
 
+USER duckdb
 CMD ["sh", "-c", "./duckdb -unsigned < ./input/$INPUT_FILE"]

--- a/src/main/docker/duckdb/Dockerfile
+++ b/src/main/docker/duckdb/Dockerfile
@@ -1,8 +1,12 @@
-FROM ubuntu:24.10
+# DuckDB CLI container image.
+# Co-authored by: OpenCode and benizzio
+FROM ubuntu:24.04
 
 WORKDIR /duckdb
 
-RUN apt update -y && apt upgrade -y && apt install -y wget unzip && apt clean
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends unzip ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 ADD https://github.com/duckdb/duckdb/releases/download/v1.2.2/duckdb_cli-linux-amd64.zip /duckdb/duckdb.zip
 RUN unzip duckdb.zip && rm duckdb.zip
 


### PR DESCRIPTION
## Summary

- move the DuckDB CLI container from the unsupported Ubuntu 24.10 image to Ubuntu 24.04 LTS
- pin the required package versions, disable recommended packages, and remove package indexes after installation
- download DuckDB CLI v1.2.2 over HTTPS and verify its pinned SHA-256 digest before extraction
- run DuckDB as a dedicated non-root user with UID and GID `10001`

## Testing

- `docker build --no-cache --pull --tag open-asset-allocator-duckdb-cli-pr336 src/main/docker/duckdb`
- `docker run --rm --volume "$PWD/src/main/docker/duckdb:/work:ro" hadolint/hadolint:v2.14.0 hadolint /work/Dockerfile`
- `docker run --rm open-asset-allocator-duckdb-cli-pr336 ./duckdb --version` (`v1.2.2 7c039464e4`)
- `docker run --rm open-asset-allocator-duckdb-cli-pr336 id -u` (`10001`)
- verified the non-root user can read SQL input from a read-only bind mount